### PR TITLE
Add option to pass stripVersion to copy plugin for default artifact

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
@@ -94,6 +94,13 @@ public class BundleMojo extends BasePayaraMojo {
     private Boolean autoDeployArtifact;
 
     /**
+     * Strip the version off the copied produced artifact <b>war</b> file. This is useful as Payara Micro forces the deployment context to the <b>war</b> file name.
+     * E.g. @{code MICRO-INF/deploy/example-1.0.0-SNAPSHOT.war} becomes @{code MICRO-INF/deploy/example.war}.
+     */
+    @Parameter(property = "stripVersionDefaultArtifact", defaultValue = "false")
+    private Boolean stripVersionDefaultArtifact;
+
+    /**
      * Replaces the @{code Start-Class} definition that resides in MANIFEST.MF file with the provided class.
      */
     @Parameter(property = "startClass")
@@ -127,7 +134,7 @@ public class BundleMojo extends BasePayaraMojo {
         customJarCopyProcessor.set(customJars).next(customFileCopyProcessor);
         customFileCopyProcessor.next(bootCommandFileCopyProcessor);
         bootCommandFileCopyProcessor.next(artifactDeployProcessor);
-        artifactDeployProcessor.set(autoDeployArtifact, mavenProject.getPackaging()).next(definedArtifactDeployProcessor);
+        artifactDeployProcessor.set(autoDeployArtifact, mavenProject.getPackaging(), stripVersionDefaultArtifact).next(definedArtifactDeployProcessor);
         definedArtifactDeployProcessor.set(deployArtifacts).next(startClassReplaceProcessor);
         startClassReplaceProcessor.set(startClass).next(systemPropAppendProcessor);
         systemPropAppendProcessor.set(appendSystemProperties).next(microJarBundleProcessor);

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
@@ -50,6 +50,7 @@ public class ArtifactDeployProcessor extends BaseProcessor {
 
     private Boolean autoDeployArtifact;
     private String packaging;
+    private Boolean stripVersion;
 
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
@@ -65,6 +66,7 @@ public class ArtifactDeployProcessor extends BaseProcessor {
                                             element("type", "${project.packaging}")
                                     )
                             ),
+                            element(name("stripVersion"), stripVersion.toString()),
                             element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_DEPLOY_FOLDER)
                     ),
                     environment
@@ -74,9 +76,10 @@ public class ArtifactDeployProcessor extends BaseProcessor {
         gotoNext(environment);
     }
 
-    public BaseProcessor set(Boolean autoDeployArtifact, String packaging) {
+    public BaseProcessor set(Boolean autoDeployArtifact, String packaging, Boolean stripVersion) {
         this.autoDeployArtifact = autoDeployArtifact;
         this.packaging = packaging;
+        this.stripVersion = stripVersion;
         return this;
     }
 }


### PR DESCRIPTION
Payara Micro forces the context of a deployed WAR file to the name of the WAR. The plugin currently copies the default artifact (created during maven package/install) including the version number. This results in the deployed context including the version number.

This adds the ability to strip the version off the WAR by passing through the `<stripVersion>true</stripVersion>` parameter to maven-dependencies-plugin `copy`.

A new configuration parameter is added called `stripVersionDefaultArtifact`. Feel free to change naming, this is the best I could think of at the time. Existing default behaviour is kept by the default value of `false`.