### PR TITLE
Fix for #13: payara-micro:bundle ignores finalName

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
@@ -132,7 +132,7 @@ public class BundleMojo extends BasePayaraMojo {
         customJarCopyProcessor.set(customJars).next(customFileCopyProcessor);
         customFileCopyProcessor.next(bootCommandFileCopyProcessor);
         bootCommandFileCopyProcessor.next(artifactDeployProcessor);
-        artifactDeployProcessor.set(autoDeployArtifact, mavenProject.getPackaging()).next(definedArtifactDeployProcessor);
+        artifactDeployProcessor.set(autoDeployArtifact, mavenProject.getPackaging(), mavenProject.getBuild().getFinalName()).next(definedArtifactDeployProcessor);
         definedArtifactDeployProcessor.set(deployArtifacts).next(startClassReplaceProcessor);
         startClassReplaceProcessor.set(startClass).next(systemPropAppendProcessor);
         systemPropAppendProcessor.set(appendSystemProperties).next(microJarBundleProcessor);

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
@@ -50,33 +50,54 @@ public class ArtifactDeployProcessor extends BaseProcessor {
 
     private Boolean autoDeployArtifact;
     private String packaging;
+    private String finalName;
 
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
         if (autoDeployArtifact && WAR_EXTENSION.equalsIgnoreCase(packaging)) {
-            executeMojo(dependencyPlugin,
-                    goal("copy"),
-                    configuration(
-                            element(name("artifactItems"),
-                                    element(name("artifactItem"),
-                                            element("groupId", "${project.groupId}"),
-                                            element("artifactId", "${project.artifactId}"),
-                                            element("version", "${project.version}"),
-                                            element("type", "${project.packaging}")
-                                    )
-                            ),
-                            element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_DEPLOY_FOLDER)
-                    ),
-                    environment
-            );
+            if (finalName != null && !finalName.isEmpty()) {
+                executeMojo(resourcesPlugin,
+                        goal("copy-resources"),
+                        configuration(
+                                element(name("resources"),
+                                        element(name("resource"),
+                                                element("directory", "${project.build.directory}"),
+                                                element(name("includes"),
+                                                        element("include", finalName + "." + packaging)
+                                                )
+                                        )
+                                ),
+                                element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_DEPLOY_FOLDER)
+                        ),
+                        environment
+                );
+            }
+            else {
+                executeMojo(dependencyPlugin,
+                        goal("copy"),
+                        configuration(
+                                element(name("artifactItems"),
+                                        element(name("artifactItem"),
+                                                element("groupId", "${project.groupId}"),
+                                                element("artifactId", "${project.artifactId}"),
+                                                element("version", "${project.version}"),
+                                                element("type", "${project.packaging}")
+                                        )
+                                ),
+                                element(name("outputDirectory"), OUTPUT_FOLDER + MICROINF_DEPLOY_FOLDER)
+                        ),
+                        environment
+                );
+            }
         }
 
         gotoNext(environment);
     }
 
-    public BaseProcessor set(Boolean autoDeployArtifact, String packaging) {
+    public BaseProcessor set(Boolean autoDeployArtifact, String packaging, String finalName) {
         this.autoDeployArtifact = autoDeployArtifact;
         this.packaging = packaging;
+        this.finalName = finalName;
         return this;
     }
 }

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
@@ -38,6 +38,7 @@
  */
 package fish.payara.maven.plugins.micro.processor;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
 
@@ -55,7 +56,7 @@ public class ArtifactDeployProcessor extends BaseProcessor {
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
         if (autoDeployArtifact && WAR_EXTENSION.equalsIgnoreCase(packaging)) {
-            if (finalName != null && !finalName.isEmpty()) {
+            if (StringUtils.isNotEmpty(finalName)) {
                 executeMojo(resourcesPlugin,
                         goal("copy-resources"),
                         configuration(


### PR DESCRIPTION
Extended the BundleMojo by checking whether the finalName is set and if so using the maven-resources-plugin:copy-resources goal instead of the maven-dependency-plugin:copy goal to copy the project's war file to the payara-micro bundle's MICRO-INF/deploy directory. 