### PR TITLE
Changing the stop mojo from using SIGINT to SIGTERM as this does also…

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StopMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/StopMojo.java
@@ -113,7 +113,7 @@ public class StopMojo extends BasePayaraMojo {
     private void killProcess(String processId) {
         try {
             final Runtime re = Runtime.getRuntime();
-            Process killProcess = re.exec("kill -2 " + processId);
+            Process killProcess = re.exec("kill " + processId);
             int result = killProcess.waitFor();
             if (result != 0) {
                 getLog().error(ERROR_MESSAGE);


### PR DESCRIPTION
… work on Windows systems (with 'kill' being an alias for Stop-Process Cmdlet).

Fix for https://github.com/payara/maven-plugins/issues/15.