### PR TITLE
PAYARA-2290 Payara Micro Maven Plugin Incorrect Deployment Order

### DIFF
--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/BundleMojo.java
@@ -122,8 +122,8 @@ public class BundleMojo extends BasePayaraMojo {
         CustomJarCopyProcessor customJarCopyProcessor = new CustomJarCopyProcessor();
         CustomFileCopyProcessor customFileCopyProcessor = new CustomFileCopyProcessor();
         BootCommandFileCopyProcessor bootCommandFileCopyProcessor = new BootCommandFileCopyProcessor();
-        ArtifactDeployProcessor artifactDeployProcessor = new ArtifactDeployProcessor();
         DefinedArtifactDeployProcessor definedArtifactDeployProcessor = new DefinedArtifactDeployProcessor();
+        ArtifactDeployProcessor artifactDeployProcessor = new ArtifactDeployProcessor();
         StartClassReplaceProcessor startClassReplaceProcessor = new StartClassReplaceProcessor();
         SystemPropAppendProcessor systemPropAppendProcessor = new SystemPropAppendProcessor();
         MicroJarBundleProcessor microJarBundleProcessor = new MicroJarBundleProcessor();
@@ -131,9 +131,9 @@ public class BundleMojo extends BasePayaraMojo {
         microFetchProcessor.set(payaraVersion).next(customJarCopyProcessor);
         customJarCopyProcessor.set(customJars).next(customFileCopyProcessor);
         customFileCopyProcessor.next(bootCommandFileCopyProcessor);
-        bootCommandFileCopyProcessor.next(artifactDeployProcessor);
-        artifactDeployProcessor.set(autoDeployArtifact, mavenProject.getPackaging()).next(definedArtifactDeployProcessor);
-        definedArtifactDeployProcessor.set(deployArtifacts).next(startClassReplaceProcessor);
+        bootCommandFileCopyProcessor.next(definedArtifactDeployProcessor);
+        definedArtifactDeployProcessor.set(deployArtifacts).next(artifactDeployProcessor);
+        artifactDeployProcessor.set(autoDeployArtifact, mavenProject.getPackaging()).next(startClassReplaceProcessor);
         startClassReplaceProcessor.set(startClass).next(systemPropAppendProcessor);
         systemPropAppendProcessor.set(appendSystemProperties).next(microJarBundleProcessor);
 

--- a/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
+++ b/payara-micro-maven-plugin/src/main/java/fish/payara/maven/plugins/micro/processor/ArtifactDeployProcessor.java
@@ -38,6 +38,7 @@
  */
 package fish.payara.maven.plugins.micro.processor;
 
+import java.io.File;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.twdata.maven.mojoexecutor.MojoExecutor;
 
@@ -54,6 +55,7 @@ public class ArtifactDeployProcessor extends BaseProcessor {
     @Override
     public void handle(MojoExecutor.ExecutionEnvironment environment) throws MojoExecutionException {
         if (autoDeployArtifact && WAR_EXTENSION.equalsIgnoreCase(packaging)) {
+
             executeMojo(dependencyPlugin,
                     goal("copy"),
                     configuration(
@@ -69,6 +71,11 @@ public class ArtifactDeployProcessor extends BaseProcessor {
                     ),
                     environment
             );
+            // Payara Micro deploys based on last modified date, so make sure that the artifact file is deployed last
+            File copiedFile = new File(OUTPUT_FOLDER + MICROINF_DEPLOY_FOLDER + environment.getMavenProject().getArtifact().getFile().getName());
+            if (copiedFile.exists()) {
+                copiedFile.setLastModified(System.currentTimeMillis());
+            }
         }
 
         gotoNext(environment);


### PR DESCRIPTION
Probably a hacky fix, but I can't think of a better one short of rewriting the plugin to use the --outputUberjar flag. 

The maven plugin deploys by extracting Payara Micro, adding in all the right files, and then zipping it up again., and Payara Micro deploys by last modified date. This fix just changes the artifact's last modified date to be more recent than other dependencies.